### PR TITLE
Add support for PHP 5.4

### DIFF
--- a/album.c
+++ b/album.c
@@ -180,7 +180,7 @@ PHP_METHOD(SpotifyAlbum, browse)
         RETURN_TRUE;
 }
 
-function_entry spotifyalbum_methods[] = {
+zend_function_entry spotifyalbum_methods[] = {
 	PHP_ME(SpotifyAlbum, __construct,		NULL,	ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
 	PHP_ME(SpotifyAlbum, __destruct,		NULL,	ZEND_ACC_PUBLIC|ZEND_ACC_DTOR)
 	PHP_ME(SpotifyAlbum, getName,			NULL,	ZEND_ACC_PUBLIC)
@@ -213,8 +213,12 @@ zend_object_value spotifyalbum_create_handler(zend_class_entry *type TSRMLS_DC)
 	memset(obj, 0, sizeof(spotifyalbum_object));
 
 	zend_object_std_init(&obj->std, type TSRMLS_CC);
-    zend_hash_copy(obj->std.properties, &type->default_properties,
+    #if PHP_VERSION_ID < 50399
+    	zend_hash_copy(obj->std.properties, &type->default_properties,
         (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+    #else
+    	 object_properties_init(&(obj->std), type);
+   	#endif
 
     retval.handle = zend_objects_store_put(obj, NULL,
         spotifyalbum_free_storage, NULL TSRMLS_CC);

--- a/albumiterator.c
+++ b/albumiterator.c
@@ -188,7 +188,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_offsetUnset, 0, 0, 1)
 	ZEND_ARG_INFO(0, offset)
 ZEND_END_ARG_INFO()
 
-function_entry spotifyalbumiterator_methods[] = {
+zend_function_entry spotifyalbumiterator_methods[] = {
 	PHP_ME(SpotifyAlbumIterator, __construct,		NULL,	ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
 	PHP_ME(SpotifyAlbumIterator, __destruct,		NULL,	ZEND_ACC_PUBLIC|ZEND_ACC_DTOR)
 
@@ -227,8 +227,12 @@ zend_object_value spotifyalbumiterator_create_handler(zend_class_entry *type TSR
 	memset(obj, 0, sizeof(spotifyalbumiterator_object));
 
 	zend_object_std_init(&obj->std, type TSRMLS_CC);
-    zend_hash_copy(obj->std.properties, &type->default_properties,
+    #if PHP_VERSION_ID < 50399
+    	zend_hash_copy(obj->std.properties, &type->default_properties,
         (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+    #else
+    	 object_properties_init(&(obj->std), type);
+   	#endif
 
     retval.handle = zend_objects_store_put(obj, NULL,
         spotifyalbumiterator_free_storage, NULL TSRMLS_CC);

--- a/artist.c
+++ b/artist.c
@@ -171,7 +171,7 @@ PHP_METHOD(SpotifyArtist, __toString)
 	RETURN_STRING(sp_artist_name(p->artist), 1);
 }
 
-function_entry spotifyartist_methods[] = {
+zend_function_entry spotifyartist_methods[] = {
 	PHP_ME(SpotifyArtist, __construct,		NULL,	ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
 	PHP_ME(SpotifyArtist, __destruct,		NULL,	ZEND_ACC_PUBLIC|ZEND_ACC_DTOR)
 	PHP_ME(SpotifyArtist, getName,			NULL,	ZEND_ACC_PUBLIC)
@@ -201,8 +201,12 @@ zend_object_value spotifyartist_create_handler(zend_class_entry *type TSRMLS_DC)
 	memset(obj, 0, sizeof(spotifyartist_object));
 
 	zend_object_std_init(&obj->std, type TSRMLS_CC);
-    zend_hash_copy(obj->std.properties, &type->default_properties,
+    #if PHP_VERSION_ID < 50399
+    	zend_hash_copy(obj->std.properties, &type->default_properties,
         (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+    #else
+    	 object_properties_init(&(obj->std), type);
+   	#endif
 
     retval.handle = zend_objects_store_put(obj, NULL,
         spotifyartist_free_storage, NULL TSRMLS_CC);

--- a/playlist.c
+++ b/playlist.c
@@ -261,7 +261,7 @@ PHP_METHOD(SpotifyPlaylist, __toString)
 	RETURN_STRING(sp_playlist_name(p->playlist), 1);
 }
 
-function_entry spotifyplaylist_methods[] = {
+zend_function_entry spotifyplaylist_methods[] = {
 	PHP_ME(SpotifyPlaylist, __construct,		NULL,	ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
 	PHP_ME(SpotifyPlaylist, __destruct,			NULL,	ZEND_ACC_PUBLIC|ZEND_ACC_DTOR)
 	PHP_ME(SpotifyPlaylist, getName,			NULL,	ZEND_ACC_PUBLIC)
@@ -298,8 +298,12 @@ zend_object_value spotifyplaylist_create_handler(zend_class_entry *type TSRMLS_D
 	memset(obj, 0, sizeof(spotifyplaylist_object));
 
 	zend_object_std_init(&obj->std, type TSRMLS_CC);
-    zend_hash_copy(obj->std.properties, &type->default_properties,
+    #if PHP_VERSION_ID < 50399
+    	zend_hash_copy(obj->std.properties, &type->default_properties,
         (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+    #else
+    	 object_properties_init(&(obj->std), type);
+   	#endif
 
     retval.handle = zend_objects_store_put(obj, NULL,
         spotifyplaylist_free_storage, NULL TSRMLS_CC);

--- a/spotify.c
+++ b/spotify.c
@@ -425,7 +425,7 @@ static void log_message(sp_session *session, const char *data)
 	//php_printf("SPOTIFY_DEBUG: %s", data);
 }
 
-function_entry spotify_methods[] = {
+zend_function_entry spotify_methods[] = {
 	PHP_ME(Spotify, __construct,            NULL,   ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
 	PHP_ME(Spotify, __destruct,				NULL,	ZEND_ACC_PUBLIC|ZEND_ACC_DTOR)
 	PHP_ME(Spotify, getPlaylists,			NULL,	ZEND_ACC_PUBLIC)
@@ -462,8 +462,12 @@ zend_object_value spotify_create_handler(zend_class_entry *type TSRMLS_DC)
 	memset(obj, 0, sizeof(spotify_object));
 
 	zend_object_std_init(&obj->std, type TSRMLS_CC);
-    zend_hash_copy(obj->std.properties, &type->default_properties,
+    #if PHP_VERSION_ID < 50399
+    	zend_hash_copy(obj->std.properties, &type->default_properties,
         (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+    #else
+    	 object_properties_init(&(obj->std), type);
+   	#endif
 
     retval.handle = zend_objects_store_put(obj, NULL,
         spotify_free_storage, NULL TSRMLS_CC);

--- a/toplist.c
+++ b/toplist.c
@@ -217,7 +217,7 @@ PHP_METHOD(SpotifyToplist, __toString)
 	RETURN_STRING("SpotifyToplist", 1);
 }
 
-function_entry spotifytoplist_methods[] = {
+zend_function_entry spotifytoplist_methods[] = {
 	PHP_ME(SpotifyToplist, __construct,		NULL,	ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
 	PHP_ME(SpotifyToplist, __destruct,		NULL,	ZEND_ACC_PUBLIC|ZEND_ACC_DTOR)
 	PHP_ME(SpotifyToplist, getRegionCode,			NULL,	ZEND_ACC_PUBLIC)
@@ -246,8 +246,12 @@ zend_object_value spotifytoplist_create_handler(zend_class_entry *type TSRMLS_DC
    // obj->std.ce = type;
 
 	zend_object_std_init(&obj->std, type TSRMLS_CC);
-    zend_hash_copy(obj->std.properties, &type->default_properties,
+    #if PHP_VERSION_ID < 50399
+    	zend_hash_copy(obj->std.properties, &type->default_properties,
         (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+    #else
+    	 object_properties_init(&(obj->std), type);
+   	#endif
 
     retval.handle = zend_objects_store_put(obj, NULL,
         spotifytoplist_free_storage, NULL TSRMLS_CC);

--- a/track.c
+++ b/track.c
@@ -177,7 +177,7 @@ PHP_METHOD(SpotifyTrack, __toString)
 	RETURN_STRING(sp_track_name(p->track), 1);
 }
 
-function_entry spotifytrack_methods[] = {
+zend_function_entry spotifytrack_methods[] = {
 	PHP_ME(SpotifyTrack, __construct,            NULL,   ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
 	PHP_ME(SpotifyTrack, __destruct,	NULL,	ZEND_ACC_PUBLIC|ZEND_ACC_DTOR)
 	PHP_ME(SpotifyTrack, getName,		NULL,	ZEND_ACC_PUBLIC)
@@ -211,8 +211,12 @@ zend_object_value spotifytrack_create_handler(zend_class_entry *type TSRMLS_DC)
 	memset(obj, 0, sizeof(spotifytrack_object));
 
 	zend_object_std_init(&obj->std, type TSRMLS_CC);
-    zend_hash_copy(obj->std.properties, &type->default_properties,
+    #if PHP_VERSION_ID < 50399
+    	zend_hash_copy(obj->std.properties, &type->default_properties,
         (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+    #else
+    	 object_properties_init(&(obj->std), type);
+   	#endif
 
     retval.handle = zend_objects_store_put(obj, NULL,
         spotifytrack_free_storage, NULL TSRMLS_CC);

--- a/trackiterator.c
+++ b/trackiterator.c
@@ -221,7 +221,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_offsetUnset, 0, 0, 1)
 	ZEND_ARG_INFO(0, offset)
 ZEND_END_ARG_INFO()
 
-function_entry spotifytrackiterator_methods[] = {
+zend_function_entry spotifytrackiterator_methods[] = {
 	PHP_ME(SpotifyTrackIterator, __construct,		NULL,	ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
 	PHP_ME(SpotifyTrackIterator, __destruct,		NULL,	ZEND_ACC_PUBLIC|ZEND_ACC_DTOR)
 
@@ -260,8 +260,12 @@ zend_object_value spotifytrackiterator_create_handler(zend_class_entry *type TSR
 	memset(obj, 0, sizeof(spotifytrackiterator_object));
 
 	zend_object_std_init(&obj->std, type TSRMLS_CC);
-    zend_hash_copy(obj->std.properties, &type->default_properties,
+    #if PHP_VERSION_ID < 50399
+    	zend_hash_copy(obj->std.properties, &type->default_properties,
         (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+    #else
+    	 object_properties_init(&(obj->std), type);
+   	#endif
 
     retval.handle = zend_objects_store_put(obj, NULL,
         spotifytrackiterator_free_storage, NULL TSRMLS_CC);

--- a/user.c
+++ b/user.c
@@ -89,7 +89,7 @@ PHP_METHOD(SpotifyUser, __toString)
 	RETURN_STRING(sp_user_display_name(p->user), 1);
 }
 
-function_entry spotifyuser_methods[] = {
+zend_function_entry spotifyuser_methods[] = {
 	PHP_ME(SpotifyUser, __construct,		NULL,	ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
 	PHP_ME(SpotifyUser, __destruct,			NULL,	ZEND_ACC_PUBLIC|ZEND_ACC_DTOR)
 	PHP_ME(SpotifyUser, getName,			NULL,	ZEND_ACC_PUBLIC)
@@ -116,8 +116,12 @@ zend_object_value spotifyuser_create_handler(zend_class_entry *type TSRMLS_DC)
 	memset(obj, 0, sizeof(spotifyuser_object));
 
 	zend_object_std_init(&obj->std, type TSRMLS_CC);
-    zend_hash_copy(obj->std.properties, &type->default_properties,
+    #if PHP_VERSION_ID < 50399
+    	zend_hash_copy(obj->std.properties, &type->default_properties,
         (copy_ctor_func_t)zval_add_ref, (void *)&tmp, sizeof(zval *));
+    #else
+    	 object_properties_init(&(obj->std), type);
+   	#endif
 
     retval.handle = zend_objects_store_put(obj, NULL,
         spotifyuser_free_storage, NULL TSRMLS_CC);


### PR DESCRIPTION
I've updated the reference of the function "function_entry" for "zend_ function_entry" (more info: https://bugs.php.net/bug.php?id=60016) and the "zend_hash_copy" (https://bugs.php.net/bug.php?id=59731&edit=1), now it will compile on machines with PHP 5.4
